### PR TITLE
Polaris: Automated PR: Update express/4.17.1 to 4.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "crypto": "^1.0.1",
     "csurf": "^1.11.0",
     "dotenv": "^10.0.0",
-    "express": "^4.17.1",
+    "express": "^4.22.1",
     "express-blinker": "0.0.6",
     "express-error-handler": "^1.1.0",
     "express-fileupload": "^1.2.1",


### PR DESCRIPTION
### *high:* Update express/4.17.1 to 4.22.1 
[CVE-2024-43796](https://nvd.nist.gov/vuln/detail/CVE-2024-43796) *(high)*: Express.js web framework is vulnerable to Cross-Site Scripting (XSS) due to the improper handling of user input in the `response.redirect()` function. This could allow an attacker to execute JavaScript code on the users browser.

**Note** The attacker must be in control of the input to `response.redirect()` and the user must click before the redirect occurs.

### *high:* Update express/4.17.1 to 4.22.1 
[CVE-2022-24999](https://nvd.nist.gov/vuln/detail/CVE-2022-24999) *(high)*: qs before 6.10.3, as used in Express before 4.17.3 and other products, allows attackers to cause a Node process hang for an Express application because an __ proto__ key can be used. In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as a[__proto__]=b&a[__proto__]&a[length]=100000000. The fix was backported to qs 6.9.7, 6.8.3, 6.7.3, 6.6.1, 6.5.3, 6.4.1, 6.3.3, and 6.2.4 (and therefore Express 4.17.3, which has "deps: qs@6.9.7" in its release description, is not vulnerable).

[Click Here To See More Details On Server](https://pim.dev.polaris.blackduck.com//portfolio/portfolios//portfolio-items/69ccae14-80ce-449a-ba0c-217e76aed354/projects/75689119-4a0d-4b50-946c-3cc4a21ba521/components/061eb274-e4bf-46d0-8f9d-4fc24e1252de)