### PR TITLE
Polaris: Automated PR: Update pug/3.0.2 to 3.0.4-canary-8

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "needle": "^3.0.0",
     "nodemailer": "^6.7.0",
     "nodemon": "^2.0.13",
-    "pug": "^3.0.2",
+    "pug": "^3.0.4-canary-8",
     "serve-static": "^1.7.1"
   }
 }


### PR DESCRIPTION
## Vulnerabilities associated with pug/3.0.2
[CVE-2024-36361](https://nvd.nist.gov/vuln/detail/CVE-2024-36361) *(high)*: **A vulnerability has been reported in pug-code-gen with the following commentary:** 

Pug through 3.0.2 allows JavaScript code execution if an application accepts untrusted input for the name option of the `compileClient`, `compileFileClient`, or `compileClientWithDependenciesTracked` function. NOTE: these functions are for compiling Pug templates into JavaScript, and there would typically be no reason to allow untrusted callers.


**This vulnerability was published on the [GHSA Database](https://github.com/advisories/GHSA-3965-hpx2-q597) and has not been independently verified by [BlackDuck CyRC](https://www.blackduck.com/resources/cybersecurity-research-center.html) Team.**

[Click Here To See More Details On Server](https://pim.dev.polaris.blackduck.com//portfolio/portfolios//portfolio-items/69ccae14-80ce-449a-ba0c-217e76aed354/projects/75689119-4a0d-4b50-946c-3cc4a21ba521/components/c9de17f9-5ed6-467a-87e3-31c7ebba8eb1)