### PR TITLE
Polaris: Automated PR: Update Polaris SCA Vulnerable Components

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^0.22.0",
+    "axios": "^0.30.3",
     "body-parser": "^1.19.0",
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.5",
@@ -17,10 +17,10 @@
     "crypto": "^1.0.1",
     "csurf": "^1.11.0",
     "dotenv": "^10.0.0",
-    "express": "^4.17.1",
+    "express": "^4.22.1",
     "express-blinker": "0.0.6",
     "express-error-handler": "^1.1.0",
-    "express-fileupload": "^1.2.1",
+    "express-fileupload": "^1.5.2",
     "express-joi-validation": "^5.0.0",
     "express-rate-limit": "^5.5.0",
     "express-session": "^1.17.2",
@@ -28,13 +28,13 @@
     "joi": "^17.4.2",
     "jsonwebtoken": "^0.4.0",
     "mongodb-autoincrement": "^1.0.1",
-    "mongoose": "^6.0.11",
+    "mongoose": "^6.13.9",
     "mongoose-unique-validator": "^2.0.4",
     "multer": "^1.4.3",
     "needle": "^3.0.0",
     "nodemailer": "^6.7.0",
     "nodemon": "^2.0.13",
-    "pug": "^3.0.2",
+    "pug": "^3.0.4-canary-8",
     "serve-static": "^1.7.1"
   }
 }


### PR DESCRIPTION
## Vulnerable components in this MR/PR
### *high:* Update express/4.17.1 to 4.22.1 
[CVE-2024-43796](https://nvd.nist.gov/vuln/detail/CVE-2024-43796) *(high)*: Express.js web framework is vulnerable to Cross-Site Scripting (XSS) due to the improper handling of user input in the `response.redirect()` function. This could allow an attacker to execute JavaScript code on the users browser.

**Note** The attacker must be in control of the input to `response.redirect()` and the user must click before the redirect occurs.

### *high:* Update express/4.17.1 to 4.22.1 
[CVE-2022-24999](https://nvd.nist.gov/vuln/detail/CVE-2022-24999) *(high)*: qs before 6.10.3, as used in Express before 4.17.3 and other products, allows attackers to cause a Node process hang for an Express application because an __ proto__ key can be used. In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as a[__proto__]=b&a[__proto__]&a[length]=100000000. The fix was backported to qs 6.9.7, 6.8.3, 6.7.3, 6.6.1, 6.5.3, 6.4.1, 6.3.3, and 6.2.4 (and therefore Express 4.17.3, which has "deps: qs@6.9.7" in its release description, is not vulnerable).

### *high:* Update axios/0.22.0 to 4.22.1 
[CVE-2023-45857](https://nvd.nist.gov/vuln/detail/CVE-2023-45857) *(high)*: Axios contains a cross-site request forgery (CSRF) vulnerability due to insecure HTTP endpoint permission validation. An attacker could exploit this vulnerability by sending a crafted link to a victim to execute malicious actions on their behalf.

**Note** Only affected if the `withCredentials` property is activated.

### *high:* Update axios/0.22.0 to 4.22.1 
[BDSA-2023-4213](https://openhub.net/vulnerabilities/bdsa/BDSA-2023-4213) *(high)*: Axios is vulnerable to cross-site scripting (XSS) via `setAttribute('href' href)` function in `/axios/dist/axios.js`. The function does not sanitize input, allowing malicious JavaScript code to be executed.

### *high:* Update axios/0.22.0 to 4.22.1 
[CVE-2025-27152](https://nvd.nist.gov/vuln/detail/CVE-2025-27152) *(high)*: Axios is vulnerable to a server-side request forgery (SSRF) issue due to how absolute URLs that are passed to Axios are handled. In cases where a user can supply a crafted value that is intended to be used along with a `baseURL` in a request, it may be possible for it to be processed in a manner that results in the request being sent to the user specified absolute URL.

This issue could be abused to send server requests to unintended endpoints and potentially allow for credential leakage.

**Warning**: The vendor provided solution for this issue is not active by default. After upgrading, users must also set the Request configuration `allowAbsoluteUrls` option to `false`. See **Solution** for more information.

### *critical:* Update mongoose/6.0.11 to 4.22.1 
[CVE-2023-3696](https://nvd.nist.gov/vuln/detail/CVE-2023-3696) *(critical)*: Mongoose is vulnerable to a prototype pollution issue due to a lack of sufficient input validation when setting the schema object. An attacker could inject a malicious payload containing a modified `Object.prototype` entry in order to potentially cause Mongoose to execute untrusted code or crash outright.

### *high:* Update mongoose/6.0.11 to 4.22.1 
[CVE-2024-53900](https://nvd.nist.gov/vuln/detail/CVE-2024-53900) *(high)*: Mongoose is vulnerable to a NoSQL injection issue due to a lack of sufficient validation of `$where` clauses in `populate()` match operations.

An attacker with the capability to run NoSQL queries could inject arbitrary code through the use of malicious `$where` clauses. This issue could allow the attacker to extract, modify or delete information from the associated NoSQL database.

### *high:* Update mongoose/6.0.11 to 4.22.1 
[CVE-2025-23061](https://nvd.nist.gov/vuln/detail/CVE-2025-23061) *(high)*: Mongoose is vulnerable to search injection due to improper use of a nested `$where` filter with a `populate()` match. This could allow an attacker to manipulate database queries, potentially leading to unauthorized data access or modification.

**Note: The authoring of this BDSA has been AI-assisted. The full technical details of the vulnerability have not been independently verified by the Black Duck Cybersecurity Research Center (CyRC).**

### *high:* Update pug/3.0.2 to 4.22.1 
[CVE-2024-36361](https://nvd.nist.gov/vuln/detail/CVE-2024-36361) *(high)*: **A vulnerability has been reported in pug-code-gen with the following commentary:** 

Pug through 3.0.2 allows JavaScript code execution if an application accepts untrusted input for the name option of the `compileClient`, `compileFileClient`, or `compileClientWithDependenciesTracked` function. NOTE: these functions are for compiling Pug templates into JavaScript, and there would typically be no reason to allow untrusted callers.


**This vulnerability was published on the [GHSA Database](https://github.com/advisories/GHSA-3965-hpx2-q597) and has not been independently verified by [BlackDuck CyRC](https://www.blackduck.com/resources/cybersecurity-research-center.html) Team.**

### *high:* Update express-fileupload/1.2.1 to 4.22.1 
[CVE-2022-27261](https://nvd.nist.gov/vuln/detail/CVE-2022-27261) *(high)*: An arbitrary file write vulnerability in Express-FileUpload v1.3.1 allows attackers to upload multiple files with the same name, causing an overwrite of files in the web application server.

[Click Here To See More Details On Server](https://pim.dev.polaris.blackduck.com//portfolio/portfolios//portfolio-items/69ccae14-80ce-449a-ba0c-217e76aed354/projects/75689119-4a0d-4b50-946c-3cc4a21ba521/components)