### PR TITLE
Polaris: Automated PR: Update body-parser/1.19.0 to 1.20.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.22.0",
-    "body-parser": "^1.19.0",
+    "body-parser": "^1.20.4",
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",


### PR DESCRIPTION
## Vulnerabilities associated with body-parser/1.19.0
[CVE-2024-45590](https://nvd.nist.gov/vuln/detail/CVE-2024-45590) *(medium)*: body-parser is vulnerable to denial-of-service (DoS) when URL encoding is enabled. An attacker could flood a server with an overwhelming number of request using a crafted payload resulting in DoS conditions.

[Click Here To See More Details On Server](https://pim.dev.polaris.blackduck.com//portfolio/portfolios//portfolio-items/69ccae14-80ce-449a-ba0c-217e76aed354/projects/75689119-4a0d-4b50-946c-3cc4a21ba521/components/e85c9b32-2c8c-4afb-a696-cc590ff5503b)